### PR TITLE
Add Python 2.7 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - '2.7'
   - '3.6'
 install:
   - yarn --ignore-engines install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## UNRELEASED
+
+### Added
+- Added a runtime validation step to interrupt the build if the user has
+   configured an unsupported runtime.
+- Added a warning if the python version implied by `runtime` is not available in
+   the build environment. Falls back to a system python.
+
 
 ## [1.0.8] - 2019-04-16 - Organization migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
    configured an unsupported runtime.
 - Added a warning if the python version implied by `runtime` is not available in
    the build environment. Falls back to a system python.
-- Tests for Python 2.7
+- Tests for Python 2.7.
+- Updated requirements discussion in `README.md` to be consistent with revised
+   requirements handling.
 
 
 ## [1.0.8] - 2019-04-16 - Organization migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    configured an unsupported runtime.
 - Added a warning if the python version implied by `runtime` is not available in
    the build environment. Falls back to a system python.
+- Tests for Python 2.7
 
 
 ## [1.0.8] - 2019-04-16 - Organization migration

--- a/README.md
+++ b/README.md
@@ -76,16 +76,16 @@ $ now
 ## Requirements
 
 Your project may optionally include a `requirements.txt` file to declare any
-dependencies. If you do include a requirements file, `Werkzeug` must appear as
-a dependency, e.g.:
+dependencies, e.g.:
 
 ```
 # requirements.txt
-Werkzeug >=0.14,<1
+Django >=2.2,<2.3
 ```
 
-If no `requirements.txt` file is included, then the builder will install
-`Werkzeug` to ensure handler dependencies are met.
+Be aware that the builder will install `Werkzeug` as a requirement of the
+handler. This can cause issues if your project requires a different version of
+`Werkzeug` than the handler.
 
 
 ## Configuration options

--- a/build-utils/index.js
+++ b/build-utils/index.js
@@ -1,0 +1,9 @@
+const log = require('./log.js');
+const pip = require('./pip.js');
+const python = require('./python.js');
+
+module.exports = {
+  log,
+  pip,
+  python,
+};

--- a/build-utils/log.js
+++ b/build-utils/log.js
@@ -12,10 +12,14 @@ function info(message) {
   message.split(/[\r\n]+/).forEach((line) => { console.log('     ', line); });
 }
 
+function warning(message) {
+  message.split(/[\r\n]+/).forEach((line) => { console.log('WARN ', line); });
+}
+
 function error(message) {
-  message.split(/[\r\n]+/).forEach((line) => { console.error(line); });
+  message.split(/[\r\n]+/).forEach((line) => { console.error('ERROR', line); });
 }
 
 module.exports = {
-  title, heading, subheading, info, error,
+  title, heading, subheading, info, warning, error,
 };

--- a/build-utils/pip.js
+++ b/build-utils/pip.js
@@ -1,0 +1,90 @@
+const path = require('path');
+const fetch = require('node-fetch');
+const execa = require('execa');
+const { createWriteStream } = require('fs');
+const getWritableDirectory = require('@now/build-utils/fs/get-writable-directory.js'); // eslint-disable-line import/no-extraneous-dependencies
+
+const log = require('./log');
+
+const url = 'https://bootstrap.pypa.io/get-pip.py';
+
+
+async function install(pipPath, srcDir, ...args) {
+  log.subheading('Installing python packages');
+  log.info(`Running "pip install -t ${srcDir} ${args.join(' ')}"`);
+  try {
+    const ret = await execa(pipPath, ['install', '-t', srcDir, ...args]);
+    log.info(ret.stdout);
+  } catch (err) {
+    log.error(`Failed to run "pip install -t ${srcDir} ${args.join(' ')}"`);
+    throw err;
+  }
+}
+
+
+async function downloadGetPipScript() {
+  const res = await fetch(url);
+
+  if (!res.ok || res.status !== 200) {
+    throw new Error(`Could not download "get-pip.py" from "${url}"`);
+  }
+
+  const dir = await getWritableDirectory();
+  const filePath = path.join(dir, 'get-pip.py');
+  const writeStream = createWriteStream(filePath);
+
+  return new Promise((resolve, reject) => {
+    res.body
+      .on('error', reject)
+      .pipe(writeStream)
+      .on('finish', () => resolve(filePath));
+  });
+}
+
+
+async function downloadAndInstallPip(pythonBin) {
+  log.subheading('Installing pip');
+
+  if (!process.env.PYTHONUSERBASE) {
+    throw new Error(
+      'Could not install "pip": "PYTHONUSERBASE" env var is not set',
+    );
+  }
+  const getPipFilePath = await downloadGetPipScript();
+
+  log.info(`Running "${pythonBin} get-pip.py"`);
+  try {
+    const ret = await execa(pythonBin, [getPipFilePath, '--user']);
+    log.info(ret.stdout);
+  } catch (err) {
+    log.error('Could not install pip');
+    throw err;
+  }
+  return path.join(process.env.PYTHONUSERBASE, 'bin', 'pip');
+}
+
+
+function findRequirements(entrypoint, files) {
+  log.subheading('Searching for "requirements.txt"');
+
+  const entryDirectory = path.dirname(entrypoint);
+  const requirementsTxt = path.join(entryDirectory, 'requirements.txt');
+
+  if (files[requirementsTxt]) {
+    log.info('Found local "requirements.txt"');
+    return files[requirementsTxt].fsPath;
+  }
+
+  if (files['requirements.txt']) {
+    log.info('Found global "requirements.txt"');
+    return files['requirements.txt'].fsPath;
+  }
+
+  log.info('No "requirements.txt" found');
+  return null;
+}
+
+
+module.exports = {
+  install, downloadAndInstallPip, findRequirements,
+};

--- a/build-utils/python.js
+++ b/build-utils/python.js
@@ -1,0 +1,60 @@
+const { sync: commandExists } = require('command-exists');
+const execa = require('execa');
+
+const log = require('./log');
+
+
+const runtimeBinaryMap = {
+  'python2.7': 'python27',
+  'python3.6': 'python36',
+};
+
+
+const fallbackBinaryMap = {
+  python36: 'python3',
+};
+
+
+async function findPythonBinary(runtime) {
+  if (!(runtime in runtimeBinaryMap)) {
+    throw new Error(`Unable to identify runtime (${runtime})`);
+  }
+
+  const binaryName = runtimeBinaryMap[runtime];
+  if (commandExists(binaryName)) {
+    log.info(`Found matching python (${binaryName})`);
+    return binaryName;
+  }
+
+  // TODO: If binary is not found, attempt install
+
+  if (!(binaryName in fallbackBinaryMap)) {
+    throw new Error(`Unable to find fallback binary for ${binaryName}`);
+  }
+  const fallbackBinary = fallbackBinaryMap[binaryName];
+  log.warning(`Unable to find matching python for ${binaryName}, falling back `
+              + `to ${fallbackBinary}`);
+  const fallbackVersion = await execa(fallbackBinary, ['--version']);
+  log.warning(`${fallbackBinary} is ${fallbackVersion.stdout}`);
+  return fallbackBinary;
+}
+
+
+function validateRuntime(runtime) {
+  if (!(runtime in runtimeBinaryMap)) {
+    log.error(`Invalid runtime configured (${runtime}). Available runtimes:`);
+    Object.keys(runtimeBinaryMap).forEach((key) => {
+      log.error(` - ${key}`);
+    });
+    log.error('See Zeit runtime documentation for more information:');
+    log.error('https://zeit.co/docs/v2/deployments/builders/developer-guide#lambdaruntime');
+    throw new Error(`Invalid runtime configured (${runtime}).`);
+  }
+  return true;
+}
+
+
+module.exports = {
+  validateRuntime,
+  findPythonBinary,
+};

--- a/now_python_wsgi/handler.py
+++ b/now_python_wsgi/handler.py
@@ -44,25 +44,6 @@ TEXT_MIME_TYPES = [
 ]
 
 
-def all_casings(input_string):
-    """
-    Permute all casings of a given string.
-    A pretty algoritm, via @Amber
-    http://stackoverflow.com/questions/6792803
-    """
-    if not input_string:
-        yield ""
-    else:
-        first = input_string[:1]
-        if first.lower() == first.upper():
-            for sub_casing in all_casings(input_string[1:]):
-                yield first + sub_casing
-        else:
-            for sub_casing in all_casings(input_string[1:]):
-                yield first.lower() + sub_casing
-                yield first.upper() + sub_casing
-
-
 def handler(app, lambda_event, context):
 
     event = json.loads(lambda_event['body'])

--- a/now_python_wsgi/handler.py
+++ b/now_python_wsgi/handler.py
@@ -20,7 +20,8 @@ from werkzeug._compat import (BytesIO, string_types, to_bytes,
                               wsgi_encoding_dance)
 
 if sys.version_info[0] < 3:
-    from urllib import urlparse, unquote
+    from urllib import unquote
+    from urlparse import urlparse
 else:
     from urllib.parse import urlparse, unquote
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ardnt/now-python-wsgi",
-  "version": "1.0.8-dev.2",
+  "version": "1.0.9-dev.2",
   "description": "Python builder for WSGI applications on Zeit Now",
   "main": "index.js",
   "repository": "https://github.com/ardnt/now-python-wsgi.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ardnt/now-python-wsgi",
-  "version": "1.0.8",
+  "version": "1.0.8-dev.1",
   "description": "Python builder for WSGI applications on Zeit Now",
   "main": "index.js",
   "repository": "https://github.com/ardnt/now-python-wsgi.git",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
+    "command-exists": "^1.2.8",
     "execa": "^1.0.0",
     "fs.promised": "^3.0.0",
     "node-fetch": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ardnt/now-python-wsgi",
-  "version": "1.0.8-dev.1",
+  "version": "1.0.8-dev.2",
   "description": "Python builder for WSGI applications on Zeit Now",
   "main": "index.js",
   "repository": "https://github.com/ardnt/now-python-wsgi.git",

--- a/tests/test_now_handler.py
+++ b/tests/test_now_handler.py
@@ -1,51 +1,105 @@
 import json
 
+import pytest
 from werkzeug.wrappers import Request, Response
 
 from now_python_wsgi import handler
 
 
-get_request_event = {
-    'Action': 'Invoke',
-    'body': json.dumps({
-        'headers': {
-            'accept': ('text/html,application/xhtml+xml,application/xml;'
-                       'q=0.9,image/webp,image/apng,*/*;q=0.8'),
-            'accept-encoding': 'gzip, deflate, br',
-            'accept-language': 'en-US,en;q=0.9',
-            'connection': 'close',
-            'host': 'python-wsgi-test.now.sh',
-            'internal-lambda-name': 'insecure-lambda-name',
-            'internal-lambda-region': 'iad1',
-            'referer': 'https://zeit.co/',
-            'upgrade-insecure-requests': '1',
-            'user-agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X '
-                           '10_14_3) AppleWebKit/537.36 (KHTML, '
-                           'like Gecko) Chrome/72.0.3626.119 '
-                           'Safari/537.36'),
-            'x-forwarded-for': '255.255.255.255',
-            'x-forwarded-host': 'python-wsgi-test.now.sh',
-            'x-forwarded-proto': 'https',
-            'x-now-deployment-url': 'python-wsgi-test.now.sh',
-            'x-now-id': 'insecure-now-id',
-            'x-now-log-id': 'insecure-now-log-id',
-            'x-now-trace': 'iad1',
-            'x-real-ip': '255.255.255.255',
-            'x-zeit-co-forwarded-for': '255.255.255.255'
-        },
-        'host': 'python-wsgi-test.now.sh',
-        'method': 'GET',
-        'path': '/'
-    }),
-}
-
+# Test applications
 
 @Request.application
 def application(request):
-    return Response('Success!')
+    return Response(json.dumps({
+        'args': request.args,
+        'query_string': request.query_string.decode('utf-8')
+    }))
 
 
-def test_now_handler_get_request():
-    response = handler(application, get_request_event, None)
+@Request.application
+def multivalue_cookie_application(request):
+    response = Response('Check cookies')
+    response.set_cookie('cookie_1', 'value_1')
+    response.set_cookie('cookie_2', 'value_2')
+    return response
+
+
+# Event helpers
+
+def prep_event(event):
+    event['body'] = json.dumps(event['body'])
+    return event
+
+
+def update_body(event, **kwargs):
+    body = event['body']
+    for key, value in kwargs.items():
+        body[key] = value
+    event['body'] = body
+    return event
+
+
+# Event fixtures
+
+@pytest.fixture
+def get_event():
+    return {
+        'Action': 'Invoke',
+        'body': {
+            'headers': {
+                'accept': ('text/html,application/xhtml+xml,application/xml;'
+                           'q=0.9,image/webp,image/apng,*/*;q=0.8'),
+                'accept-encoding': 'gzip, deflate, br',
+                'accept-language': 'en-US,en;q=0.9',
+                'connection': 'close',
+                'host': 'python-wsgi-test.now.sh',
+                'internal-lambda-name': 'insecure-lambda-name',
+                'internal-lambda-region': 'iad1',
+                'referer': 'https://zeit.co/',
+                'upgrade-insecure-requests': '1',
+                'user-agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X '
+                               '10_14_3) AppleWebKit/537.36 (KHTML, '
+                               'like Gecko) Chrome/72.0.3626.119 '
+                               'Safari/537.36'),
+                'x-forwarded-for': '255.255.255.255',
+                'x-forwarded-host': 'python-wsgi-test.now.sh',
+                'x-forwarded-proto': 'https',
+                'x-now-deployment-url': 'python-wsgi-test.now.sh',
+                'x-now-id': 'insecure-now-id',
+                'x-now-log-id': 'insecure-now-log-id',
+                'x-now-trace': 'iad1',
+                'x-real-ip': '255.255.255.255',
+                'x-zeit-co-forwarded-for': '255.255.255.255'
+            },
+            'host': 'python-wsgi-test.now.sh',
+            'method': 'GET',
+            'path': '/'
+        },
+    }
+
+
+# Tests
+
+def test_now_handler_get_request(get_event):
+    response = handler(application, prep_event(get_event), None)
     assert response['statusCode'] == 200
-    assert 'headers' in response
+
+
+def test_now_handler_querystring(get_event):
+    event = update_body(get_event, path='/?param%3Dvalue%26param2%3Dvalue2')
+    response = handler(application, prep_event(event), None)
+    assert response['statusCode'] == 200
+
+    request_data = json.loads(response['body'])
+    assert request_data['args'] == {'param': 'value', 'param2': 'value2'}
+
+
+def test_now_handler_multivalue_cookies(get_event):
+    response = handler(multivalue_cookie_application, prep_event(get_event),
+                       None)
+    assert response['statusCode'] == 200
+    assert 'Set-Cookie' in response['headers']
+    assert response['headers']['Set-Cookie'] == [
+        'cookie_1=value_1; Path=/',
+        'cookie_2=value_2; Path=/',
+    ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,11 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
+command-exists@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
+  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
### Added
- Added a runtime validation step to interrupt the build if the user has
   configured an unsupported runtime.
- Added a warning if the python version implied by `runtime` is not available in
   the build environment. Falls back to a system python.
- Tests for Python 2.7.
- Updated requirements discussion in `README.md` to be consistent with revised
   requirements handling.